### PR TITLE
Problem with running on uninstalled package, which would pull in dependencies

### DIFF
--- a/pacolog
+++ b/pacolog
@@ -50,7 +50,7 @@ if [[ $# != 1 ]]; then
 fi
 
 # Determine package's repository
-repo=$(pacman -Sp --print-format %r ${1} 2>/dev/null)
+repo=$(pacman -Spdd --print-format %r ${1} 2>/dev/null)
 
 # Determine base package, and start to build url
 package_page=$(w3m -dump "https://www.archlinux.org/packages/${repo}/x86_64/${1}/")


### PR DESCRIPTION
The tool runs the command

pacman -Sp --print-format %r ${1}

In the the specified package is not installed and has dependencies which are also not installed, this command returns the repos for all packages that would be installed, the specified package itself and all dependencies.

It seems pacolog expects to get exactly one repo name from that call, if it gets multiple it crashes.

This commit fixes the problem.